### PR TITLE
replace DefaultTilesetDec with Option row type

### DIFF
--- a/docs/examples/tilemap-from-array/src/Main.purs
+++ b/docs/examples/tilemap-from-array/src/Main.purs
@@ -5,7 +5,6 @@ module Main where
 
 import Prelude
 import Data.Array (length)
-import Data.Nullable (notNull)
 import Effect (Effect)
 import Effect.Console (log)
 import Graphics.Phaser as Phaser
@@ -62,10 +61,9 @@ create scene = do
   -- with Function"
   tileset <-
     addTilesetImage tileMap tileName
-      defaultTilesetDesc
-        { tileWidth = notNull 16 -- PS-Phaser doesn't wrap as Maybe yet
-        , tileHeight = notNull 16
-        }
+      { tileWidth: 16
+      , tileHeight: 16
+      }
   -- Another note: Forgetting to give a record as an argument to an effectful
   -- function also gives a weird error "Could not match Effect with Function"
   -- Currently defaulting layerID, x, and y to zeros.

--- a/packages.dhall
+++ b/packages.dhall
@@ -105,6 +105,6 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210825/packages.dhall sha256:eee0765aa98e0da8fc414768870ad588e7cada060f9f7c23c37385c169f74d9f
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,8 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "phaser"
-, dependencies =
-  [ "aff", "effect", "functions", "option", "prelude", "psci-support" ]
+, dependencies = [ "aff", "effect", "option", "prelude", "psci-support" ]
 , license = "MIT"
 , repository = "https://github.com/lfarroco/purescript-phaser"
 , packages = ./packages.dhall

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,13 +3,8 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "phaser"
-, dependencies = [
-    "prelude",
-    "aff",
-    "effect",
-    "psci-support",
-    "nullable",
-  ]
+, dependencies =
+  [ "aff", "effect", "functions", "option", "prelude", "psci-support" ]
 , license = "MIT"
 , repository = "https://github.com/lfarroco/purescript-phaser"
 , packages = ./packages.dhall

--- a/src/Graphics/TileMap.purs
+++ b/src/Graphics/TileMap.purs
@@ -6,11 +6,11 @@ module Graphics.Phaser.TileMap
   , tilesets
   ) where
 
-import Data.Nullable (Nullable, null)
-import Data.Show (class Show)
+import Prelude
 import Effect (Effect)
 import Effect.Uncurried (EffectFn2, EffectFn3, runEffectFn2, runEffectFn3)
 import Graphics.Phaser.ForeignTypes (PhaserLayer, PhaserScene, PhaserTileMap, PhaserTileSet)
+import Option (class FromRecord, Option, fromRecord)
 
 -- Corresponds to https://newdocs.phaser.io/docs/3.55.2/Phaser.Types.Tilemaps.TilemapConfig
 -- TODO: Current impl is missing quite a few fields, make default?
@@ -28,44 +28,38 @@ foreign import makeTileMapImpl ::
     MapDataConfig
     PhaserTileMap
 
-makeTileMap ::
-  PhaserScene ->
-  MapDataConfig ->
-  Effect PhaserTileMap
+makeTileMap :: PhaserScene -> MapDataConfig -> Effect PhaserTileMap
 makeTileMap = runEffectFn2 makeTileMapImpl
-
-type TilesetDesc
-  = { key :: Nullable String
-    , tileWidth :: Nullable Int
-    , tileHeight :: Nullable Int
-    , tileMargin :: Nullable Int
-    , tileSpacing :: Nullable Int
-    , gid :: Nullable Int
-    }
-
-defaultTilesetDesc :: TilesetDesc
-defaultTilesetDesc =
-  { key: null
-  , tileWidth: null
-  , tileHeight: null
-  , tileMargin: null
-  , tileSpacing: null
-  , gid: null
-  }
 
 foreign import addTilesetImageImpl ::
   EffectFn3
     PhaserTileMap
     String
-    TilesetDesc
+    (Option TilesetDesc)
     PhaserTileSet
 
+-- | The argument of type `given` must be any record which is a subset of
+-- | `TilesetDesc`
 addTilesetImage ::
-  PhaserTileMap ->
-  String ->
-  TilesetDesc ->
-  Effect PhaserTileSet
-addTilesetImage = runEffectFn3 addTilesetImageImpl
+  forall given.
+  FromRecord given () TilesetDesc =>
+  PhaserTileMap -> String -> Record given -> Effect PhaserTileSet
+addTilesetImage tileMap tilesetName given =
+  runEffectFn3
+    addTilesetImageImpl
+    tileMap
+    tilesetName
+    -- Pass the given record to js, which expects an option type
+    (fromRecord given)
+
+type TilesetDesc
+  = ( key :: String
+    , tileWidth :: Int
+    , tileHeight :: Int
+    , tileMargin :: Int
+    , tileSpacing :: Int
+    , gid :: Int
+    )
 
 foreign import createLayerImpl ::
   forall a.

--- a/src/Graphics/TileMap.purs
+++ b/src/Graphics/TileMap.purs
@@ -1,6 +1,5 @@
 module Graphics.Phaser.TileMap
   ( makeTileMap
-  , defaultTilesetDesc
   , createLayer
   , addTilesetImage
   , tilesets
@@ -77,6 +76,5 @@ createLayer ::
   Array PhaserTileSet ->
   Effect PhaserLayer
 createLayer = runEffectFn3 createLayerImpl
-
 
 foreign import tilesets :: PhaserTileMap -> Array PhaserTileSet


### PR DESCRIPTION
Possible solution for #3. This is a proposal to use the Option row type to express large records with many allowable nulls. The benefits are fairly good for the user.
The api seems to become easier to work with and users will no longer need to update default* types. The main problem I see is row types are harder to understand. It will be a bit harder for contributors to modify code. Users will also see much more confusing types for functions that accept Option rows.
